### PR TITLE
Enabled optional support for .jsx files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,17 +30,21 @@ const config = {
     historyApiFallback: true,
     publicPath: '/'
   },
+  
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
 
   module: {
     rules: [
       {
         enforce: "pre",
-        test: /\.js$/,
+        test: /\.jsx?$/,
         exclude: /node_modules/,
         loader: "eslint-loader"
       },
       {
-        test: /\.js$/,
+        test: /\.jsx?$/,
         loaders: [
           'babel-loader',
         ],
@@ -131,7 +135,7 @@ const config = {
 
   plugins: [
     new webpack.LoaderOptionsPlugin({
-      test: /\.js$/,
+      test: /\.jsx?$/,
       options: {
         eslint: {
           configFile: resolve(__dirname, '.eslintrc'),

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -40,10 +40,14 @@ const config = {
     new CopyWebpackPlugin([{ from: './vendors', to: 'vendors' }]),
   ],
 
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
+
   module: {
     loaders: [
       {
-        test: /\.js?$/,
+        test: /\.jsx?$/,
         exclude: /node_modules/,
         loader: 'babel-loader',
       },


### PR DESCRIPTION
This enables .js and .jsx components to be mixed and matched, however a recompile is necessary if renaming one to the other.