### PR TITLE
added support for heroku post build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "precommit": "cross-env npm run lint && npm test",
     "prepush": "cross-env npm run lint && npm test",
     "webpack:dev": "webpack --colors",
-    "webpack:prod": "webpack --config webpack.production.config.js --colors"
+    "webpack:prod": "webpack --config webpack.production.config.js --colors",
+    "heroku-postbuild": "npm run production"
   },
   "author": "Kliment Petrov <kleopetroff@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
We need a production build before deploying it to Heroku, So I have added `heroku-postbuild` command in package.json, so it will create production build whenever someone deploys the application to Heroku